### PR TITLE
PDB Scan: More comprehensive warnings about chain begining residues

### DIFF
--- a/src/sassie/build/pdbscan/pdbscan/report.py
+++ b/src/sassie/build/pdbscan/pdbscan/report.py
@@ -190,6 +190,8 @@ def generate_simulation_prep_report(mol):
     just = ['c','c','c','c','c']
     contents = []
 
+    start_warnings = []
+
     for segname in segname_list:
 
         checks = sim_ready_checks[segname]
@@ -203,7 +205,18 @@ def generate_simulation_prep_report(mol):
 
         contents.append(line)
 
+        if not checks['start']:
+            start_warnings.append(segname)
+
     rep += pdt.create_pandoc_table(header, contents, widths, just)
+
+    if start_warnings:
+        rep.append('\n')
+        warn_txt = ('WARNING: Segments {:s} do not start with resid 1, check '
+                   'sequence is correct\n'.format(','.join(start_warnings)))
+
+        rep.append(warn_txt)
+
 
     return rep
 

--- a/src/sassie/build/pdbscan/pdbscan/report.py
+++ b/src/sassie/build/pdbscan/pdbscan/report.py
@@ -150,8 +150,6 @@ def generate_simulation_prep_report(mol):
     rep.append('parameterized structures. PDB Scan suggests the following ')
     rep.append('mapping of residues from the input chains to segments.\n')
 
-    #widths = [6, 7, 15, 19]
-    #just = ['l', 'l', 'l','l']
     widths = [6, 7, 4, 13, 16]
     just = ['l', 'l', 'l','l','l']
     contents = []
@@ -171,7 +169,6 @@ def generate_simulation_prep_report(mol):
             index_range = str(atom_info['original_index'][0]) + '-' + str(atom_info['original_index'][1])
             seg_moltype = atom_info['moltype'][:3]
 
-            #tmp_contents.append([chain, segname, resid_range, index_range])
             tmp_contents.append([chain, segname, seg_moltype, resid_range, index_range])
 
         contents += sorted(tmp_contents, key = lambda x: x[3])
@@ -179,8 +176,6 @@ def generate_simulation_prep_report(mol):
     for line in contents:
         segname_list.append(line[1])
 
-
-    #header = ['Chain','Segname','Resids','Indices']
     header = ['Chain','Segname','Type','Resids','Indices']
 
     rep += pdt.create_pandoc_table(header, contents, widths, just)
@@ -195,7 +190,6 @@ def generate_simulation_prep_report(mol):
     just = ['c','c','c','c','c']
     contents = []
 
-    #for segname, checks in sim_ready_checks.iteritems():
     for segname in segname_list:
 
         checks = sim_ready_checks[segname]

--- a/src/sassie/build/pdbscan/pdbscan/scanner.py
+++ b/src/sassie/build/pdbscan/pdbscan/scanner.py
@@ -2325,6 +2325,11 @@ class SasMolScan(sasmol.SasMol):
                                         sim_ready[segname]['chain'] and
                                         sim_ready[segname]['single_conformer'])
 
+            # We should warn people if start residue is not 1
+            first_resid = self.segname_info.sequence[segname][0][0]
+
+            sim_ready[segname]['start'] = (first_resid == 1)
+
         return
 
     def check_protein_residue_dihed_atoms(self, ndxs):


### PR DESCRIPTION
Added an explicit warning to the PDB Scan report for segments that do not start at residue 1.

In response to  http://www.smallangles.net/sassie/trac/ticket/526
