### PR TITLE
Fix for at least some minimal header containing PDBs

### DIFF
--- a/src/sassie/build/pdbscan/gui_mimic_pdbscan.py
+++ b/src/sassie/build/pdbscan/gui_mimic_pdbscan.py
@@ -25,6 +25,8 @@ pdbfile='testing/data/1984.pdb'
 pdbfile='testing/data/7361.pdb'
 pdbfile='testing/data/732.pdb'
 pdbfile='testing/data/8068.pdb'
+pdbfile='testing/data/hiv1_gag.pdb'
+pdbfile='testing/data/small.pdb'
 #pdbfile='testing/data/5E3L.pdb'
 
 #### end user input ####

--- a/src/sassie/build/pdbscan/pdbscan/scanner.py
+++ b/src/sassie/build/pdbscan/pdbscan/scanner.py
@@ -2160,10 +2160,6 @@ class SasMolScan(sasmol.SasMol):
         chain_info = self.chain_info
         segname_info = self.segname_info
 
-        #seg_chain_map = np.array(zip(segnames, chains))
-
-        ###TODO: added by dww 4/30/2018
-
         seg_chain_map = np.empty(len(chains), dtype='O')
         tmp = zip(segnames, chains)
         seg_chain_map[:] = tmp

--- a/src/sassie/build/pdbscan/pdbscan/scanner.py
+++ b/src/sassie/build/pdbscan/pdbscan/scanner.py
@@ -132,8 +132,7 @@ class SasMolScan(sasmol.SasMol):
         kwargs['pdbscan'] = True
         super(SasMolScan, self).read_pdb(filename, **kwargs)
 
-        self.header_data = header_reader.PdbHeader(
-            text=self.header(), parse=True)
+        self.header_data = header_reader.PdbHeader(sasmol=self, parse=True)
 
         self.charmm = [False] * self.natoms()
         self.md_ready = [False] * self.natoms()


### PR DESCRIPTION
Now runs both ATOM ony version of `small.pdb` and post-psfgen version with odd REMARK records (+ couple of proper header containing PDBs).