### PR TITLE
First attempt to handle rescodes properly

### DIFF
--- a/src/sassie/build/pdbscan/pdbscan/report.py
+++ b/src/sassie/build/pdbscan/pdbscan/report.py
@@ -47,17 +47,21 @@ def generate_reports(mol):
 
     short_report.append('# PDB Scan report for ' + mol.pdbname + '\n')
 
-    edited_resids = []
+    edited_chains = []
 
     for chain, was_edited in mol.chain_resid_edited.iteritems():
 
         if was_edited:
-            edited_resids.append('Chain {0:s}'.format(chain))
+            edited_chains.append(chain)
 
-    if edited_resids:
+    if edited_chains:
 
-        short_report.append('## Residue numbers edited to account for insertions\n')
-        short_report += edited_resids
+        short_report.append('##Residue numbers edited to account for insertions')
+        if len(edited_chains) > 1:
+            short_report += ['Chains: ' + ' '.join(edited_chains)]
+        else:
+            short_report += ['Chain: ' + ' '.join(edited_chains)]
+        short_report += ['\n']
 
     reconciliation_report = generate_reconciliation_report(mol)
 

--- a/src/sassie/build/pdbscan/pdbscan/report.py
+++ b/src/sassie/build/pdbscan/pdbscan/report.py
@@ -47,6 +47,18 @@ def generate_reports(mol):
 
     short_report.append('# PDB Scan report for ' + mol.pdbname + '\n')
 
+    edited_resids = []
+
+    for chain, was_edited in mol.chain_resid_edited.iteritems():
+
+        if was_edited:
+            edited_resids.append('Chain {0:s}'.format(chain))
+
+    if edited_resids:
+
+        short_report.append('## Residue numbers edited to account for insertions\n')
+        short_report += edited_resids
+
     reconciliation_report = generate_reconciliation_report(mol)
 
     if reconciliation_report:

--- a/src/sassie/build/pdbscan/pdbscan/scanner.py
+++ b/src/sassie/build/pdbscan/pdbscan/scanner.py
@@ -137,7 +137,31 @@ class SasMolScan(sasmol.SasMol):
         self.charmm = [False] * self.natoms()
         self.md_ready = [False] * self.natoms()
 
+        self._seq_res = self.resid()
+        self.separate_rescodes()
+
         self.basic_checks()
+
+        return
+
+    def seq_res(self):
+        return self._seq_res
+
+    def setSeqRes(self, newValue):
+        self._seq_res = newValue
+
+    def separate_rescodes(self):
+        """
+
+        """
+
+        resids = self.resid()
+        rescodes = self.rescode()
+        chains = self.chain()
+
+        
+
+        self.setResids(resids)
 
         return
 


### PR DESCRIPTION
So I gave up trying to do this elegantly and went with the following approach:
- Copy existing resids to orig_resids
- Loop through all chains and split resids with rescodes (new resid numbering preserves gap sizes in original numbering including at the start of a chain).

The advantage is that no other code needs changing and sequences now align properly. The disadvantage is that it means editing the original numbers, but this will happen when making models any way.

I've tested this on only a couple of PDBs using Scan only - but there is no reason it should present issues for remotely well formed PDBs.